### PR TITLE
Remove debug file write

### DIFF
--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -525,8 +525,6 @@ pub async fn submit_sampler_job(
         runtime,
         tags,
     );
-    let file = File::create("/tmp/test.json").unwrap();
-    serde_json::to_writer_pretty(file, &job_payload).unwrap();
     let res = create_job(
         &service.quantum_config,
         crn,


### PR DESCRIPTION
In the initial bring up of the job submission workflow to figure out if the generated job payload was valid or not the client code was configured to write out the request payload body to a file in /tmp. This was primarily done for debugging to verify the correct payload was generated and check the payload. However after the client was working the validation here was not needed anymore, but removing it was overlooked. This has been fully superseded by the logging mechanism and doesn't provide general debugging. This commit fixes this oversight and removes the file write.