### PR TITLE
Add `const` markers to C declarations and `QkCircuit`

### DIFF
--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -45,7 +45,7 @@ macro_rules! check_result {
 ///
 /// It's C so it's never safe
 #[no_mangle]
-pub unsafe extern "C" fn generate_qpy(circuit: *mut QkCircuit, filename: *const c_char) {
+pub unsafe extern "C" fn generate_qpy(circuit: *const QkCircuit, filename: *const c_char) {
     let circuit = Circuit(circuit);
     let path = unsafe { Path::new(CStr::from_ptr(filename).to_str().unwrap()) };
     let mut file = File::create(path).unwrap();
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn generate_qpy(circuit: *mut QkCircuit, filename: *const 
 /// It's C so it's never safe
 #[no_mangle]
 pub unsafe extern "C" fn qkrt_sampler_job_write_payload(
-    circuit: *mut QkCircuit,
+    circuit: *const QkCircuit,
     shots: i32,
     backend: *const c_char,
     runtime: *const c_char,

--- a/tests/test_job_create.c
+++ b/tests/test_job_create.c
@@ -18,11 +18,11 @@
 #include <stdio.h>
 #include <string.h>
 
-extern void generate_qpy(QkCircuit *circuit, char *filename);
+extern void generate_qpy(const QkCircuit *circuit, const char *filename);
 
-extern void qkrt_sampler_job_write_payload(QkCircuit *circuit, int32_t shots,
-                                           char *backend, char *runtime,
-                                           char *filename);
+extern void qkrt_sampler_job_write_payload(const QkCircuit *circuit, int32_t shots,
+                                           const char *backend, const char *runtime,
+                                           const char *filename);
 
 int main(int argc, char *arv[]) {
     QkCircuit *qc = qk_circuit_new(100, 100);

--- a/tests/test_qpy.c
+++ b/tests/test_qpy.c
@@ -15,7 +15,7 @@
 
 #include <qiskit.h>
 
-extern void generate_qpy(QkCircuit *circuit, char *filename);
+extern void generate_qpy(const QkCircuit *circuit, const char *filename);
 
 int main(int argc, char* arv[]) {
     QkCircuit *qc = qk_circuit_new(200, 200);


### PR DESCRIPTION
This adds the `const` markers that I thought should be there.  I modified a bit of Rust code, but perhaps I don't understand some way in which the `QkCircuit` might be modified.  On the other hand, if I am to trust the Rust compiler, then I must not have missed anything. :slightly_smiling_face: 

- [ ] modify the header file too