### PR TITLE
Log warnings on unknown gate types instead of panicking

### DIFF
--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -468,6 +468,11 @@ pub async fn get_backend(service: &Service, backend: &Backend) -> crate::qiskit_
             // TODO: Add RZZ support when we have angle wrapping in
             // Qiskit's target and C transpiler.
             //            crate::qiskit_target::ISAGate::RZZ
+            log_warn(&concat!(
+                "rzz gate's constraints can be properly represented in the target ",
+                "currently. It is being excluded from the target generated for ",
+                "this backend."
+            ));
             continue;
         } else if gate == "reset" {
             target.add_reset(
@@ -477,7 +482,9 @@ pub async fn get_backend(service: &Service, backend: &Backend) -> crate::qiskit_
             );
             continue;
         } else {
-            panic!("What is a {gate}?");
+            log_warn(&format!(
+                "{gate} can not be represented in the Target for {name} because it does not correspond to a Qiskit standard operation. It will not be included in the target generated for this backend."));
+            continue;
         };
         target.add_gate(
             gate,

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -469,7 +469,7 @@ pub async fn get_backend(service: &Service, backend: &Backend) -> crate::qiskit_
             // Qiskit's target and C transpiler.
             //            crate::qiskit_target::ISAGate::RZZ
             log_warn(&concat!(
-                "rzz gate's constraints can be properly represented in the target ",
+                "rzz gate's constraints cannot be represented in the target from C ",
                 "currently. It is being excluded from the target generated for ",
                 "this backend."
             ));


### PR DESCRIPTION
This commit fixes the processing when encountering a custom gate that is outside Qiskit's standard operations when generating a target for an IBM backend. Several IBM backends can contain details for custom operations specific to a given backend. In Python these are defined with custom operation classes to define the semantics of the operation and then added to the target. The Qiskit C API doesn't yet offer this level of flexibility and can't represent these custom operations in the target. During the bring up of this library for testing encountering these custom operations would just panic which was fine for testing, but is not desirable behavior when actually using the library. This commit switches to logging a warning whenever a backend's properties indicate it supports gate or operation that Qiskit's C API can't represent currently. It will no longer crash the program when trying to build the target in these cases.