### PR TITLE
Fixes CMake build with Ninja backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,6 @@ add_custom_command(
         --locked
         --target-dir ${CARGO_TARGET_DIR}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        BYPRODUCTS ${RUST_LIBPATH}
         COMMENT "Building Rust library (cargo ${CARGO_PROFILE} → ${RUST_LIBPATH})"
         VERBATIM
 )


### PR DESCRIPTION
Hello,

When using the Ninja generator with CMake, we get the following error when building:

```
ninja: error: build.ninja:392: cargo/debug/libqiskit_ibm_runtime.so is defined as an output multiple times
```

This is because the shared library is defined twice in the main CMake file, which leads to this doubly defined output. You can reproduce this by configuring and building with CMake using the Ninja generator:

```
cmake -GNinja -Bbuild/ .
cmake --build build/
```

Removing the byproduct eliminates this error, and does not change the build behavior. Let me know if this has side effects that I am not seeing.

Thanks!