### PR TITLE
Feature/samples num bits

### DIFF
--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -295,6 +295,11 @@ pub unsafe extern "C" fn qkrt_samples_num_samples(samples: *const Samples) -> us
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn qkrt_samples_num_bits(samples: *const Samples) -> u32 {
+    unsafe { const_ptr_as_ref(samples) }.1
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn qkrt_samples_get_sample(
     samples: *const Samples,
     index: usize,

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -564,7 +564,7 @@ pub async fn get_job_details(service: &Service, job: &Job) -> Result<JobDetails,
 }
 
 #[derive(Debug)]
-pub struct Samples(pub Vec<String>);
+pub struct Samples(pub Vec<String>, pub u32); //mod : samples -> samples ,bitstringlength
 
 pub async fn get_job_results(service: &Service, job: &Job) -> Result<Samples, ServiceError> {
     let crn = job.instance.crn.to_str().unwrap();
@@ -575,7 +575,8 @@ pub async fn get_job_results(service: &Service, job: &Job) -> Result<Samples, Se
         Some("2025-06-01"),
     )
     .await?;
-    log_debug(&format!("get_job_result response: {:?}", details));
+    log_debug(&format!("get_job_result response: {:?}", details)); 
+    let num_bits = details.results[0].data["meas"].num_bits; //mod : get num_bits from results
     let res = Ok(Samples(
         details
             .results
@@ -583,6 +584,7 @@ pub async fn get_job_results(service: &Service, job: &Job) -> Result<Samples, Se
             .flat_map(|x| x.data["meas"].samples.iter())
             .cloned()
             .collect(),
+            num_bits,  //mod : bitstringlength
     ));
     res
 }

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -564,7 +564,7 @@ pub async fn get_job_details(service: &Service, job: &Job) -> Result<JobDetails,
 }
 
 #[derive(Debug)]
-pub struct Samples(pub Vec<String>, pub u32); //mod : samples -> samples ,bitstringlength
+pub struct Samples(pub Vec<String>, pub u32);
 
 pub async fn get_job_results(service: &Service, job: &Job) -> Result<Samples, ServiceError> {
     let crn = job.instance.crn.to_str().unwrap();
@@ -575,8 +575,8 @@ pub async fn get_job_results(service: &Service, job: &Job) -> Result<Samples, Se
         Some("2025-06-01"),
     )
     .await?;
-    log_debug(&format!("get_job_result response: {:?}", details)); 
-    let num_bits = details.results[0].data["meas"].num_bits; //mod : get num_bits from results
+    log_debug(&format!("get_job_result response: {:?}", details));
+    let num_bits = details.results[0].data["meas"].num_bits;
     let res = Ok(Samples(
         details
             .results
@@ -584,7 +584,7 @@ pub async fn get_job_results(service: &Service, job: &Job) -> Result<Samples, Se
             .flat_map(|x| x.data["meas"].samples.iter())
             .cloned()
             .collect(),
-            num_bits,  //mod : bitstringlength
+        num_bits,
     ));
     res
 }

--- a/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
+++ b/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
@@ -168,6 +168,15 @@ extern int32_t qkrt_job_results(Samples **out, Service *service, Job *job);
 extern size_t qkrt_samples_num_samples(const Samples *samples);
 
 /**
+ * Get the number of classical bits in each sample.
+ *
+ * @param samples The handle of the samples.
+ *
+ * @return The number of bits per sample.
+ */
+extern uint32_t qkrt_samples_num_bits(const Samples *samples);
+
+/**
  * Get a specific sample by index.
  *
  * @param samples The handle of the samples.

--- a/samples/test_ghz_run.c
+++ b/samples/test_ghz_run.c
@@ -94,10 +94,22 @@ int main(int argc, char *arv[]) {
         printf("current status: %d\n", status);
     } while (status == 0 || status == 1);
     printf("job terminated with status: %d\n", status);
+    // Samples *samples;
+    // res = qkrt_job_results(&samples, service, job);
+
+    // printf("Job has %d samples\nThe first sample is:\n", qkrt_samples_num_samples(samples));
+    // char *first_sample = qkrt_samples_get_sample(samples, 0);
+    // printf("%s\n", first_sample);
+    // qkrt_str_free(first_sample);
+    // qkrt_samples_free(samples);
     Samples *samples;
     res = qkrt_job_results(&samples, service, job);
 
-    printf("Job has %d samples\nThe first sample is:\n", qkrt_samples_num_samples(samples));
+    uint32_t num_bits = qkrt_samples_num_bits(samples); 
+    size_t num_samples = qkrt_samples_num_samples(samples);
+    
+    printf("Job has %zu samples with %u bits each\n", num_samples, num_bits);
+    printf("The first sample is:\n");
     char *first_sample = qkrt_samples_get_sample(samples, 0);
     printf("%s\n", first_sample);
     qkrt_str_free(first_sample);

--- a/samples/test_ghz_run.c
+++ b/samples/test_ghz_run.c
@@ -94,18 +94,10 @@ int main(int argc, char *arv[]) {
         printf("current status: %d\n", status);
     } while (status == 0 || status == 1);
     printf("job terminated with status: %d\n", status);
-    // Samples *samples;
-    // res = qkrt_job_results(&samples, service, job);
-
-    // printf("Job has %d samples\nThe first sample is:\n", qkrt_samples_num_samples(samples));
-    // char *first_sample = qkrt_samples_get_sample(samples, 0);
-    // printf("%s\n", first_sample);
-    // qkrt_str_free(first_sample);
-    // qkrt_samples_free(samples);
     Samples *samples;
     res = qkrt_job_results(&samples, service, job);
 
-    uint32_t num_bits = qkrt_samples_num_bits(samples); 
+    uint32_t num_bits = qkrt_samples_num_bits(samples);
     size_t num_samples = qkrt_samples_num_samples(samples);
     
     printf("Job has %zu samples with %u bits each\n", num_samples, num_bits);


### PR DESCRIPTION
Add Samples bit-width helper so bindings know how many classical bits every sample carries. This fixes #8
The function returns the bit count, so clients can parse hex strings into correct-length bit vectors without guessing.

- [x] Expose qkrt_samples_num_bits in the public header and implementation.
- [x] Add Tests
- [x] Format code
