### PR TITLE
Fix compiler warnings with latest rust in client crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build
-        run: cmake --build build --config Release --parallel
+        run: cmake --build build --config Release
       - name: Test
         run: ctest --test-dir build --output-on-failure -C Release

--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use crate::service::{
     get_account_from_config, get_backend, get_backends, get_job_details, get_job_results,
     get_job_status, list_instances, submit_sampler_job, Backend, BackendSearchResults, Job,
-    JobDetails, Samples, Service, ServiceError,
+    JobDetails, Samples, Service,
 };
 
 macro_rules! check_result {
@@ -99,10 +99,7 @@ pub unsafe extern "C" fn qkrt_service_new(out: *mut *mut Service) -> ExitCode {
     let mut instances = check_result!(rt.block_on(list_instances(&account)));
     if let Some(instance) = &account.config.instance {
         // Filter-out any instance that doesn't match the user's config.
-        instances = instances
-            .into_iter()
-            .filter(|x| &x.crn.to_str().unwrap() == &instance)
-            .collect()
+        instances.retain(|x| x.crn.to_str().unwrap() == instance)
     }
     *out = Box::into_raw(Box::new(Service::new(account, instances)));
     ExitCode::Success

--- a/crates/client/src/qiskit_circuit.rs
+++ b/crates/client/src/qiskit_circuit.rs
@@ -31,7 +31,7 @@ pub struct CircuitInstructions<'a> {
 impl<'a> Drop for CircuitInstructions<'a> {
     fn drop(&mut self) {
         unsafe {
-            qiskit_ffi::qk_circuit_instruction_clear(&mut self.inst);
+            qiskit_ffi::qk_circuit_instruction_clear(&self.inst);
         }
     }
 }
@@ -51,7 +51,7 @@ impl<'a> Iterator for CircuitInstructions<'a> {
         }
         let out = unsafe {
             if self.index > 0 {
-                qiskit_ffi::qk_circuit_instruction_clear(&mut self.inst);
+                qiskit_ffi::qk_circuit_instruction_clear(&self.inst);
             }
             qiskit_ffi::qk_circuit_get_instruction(self.circuit.0, self.index, &mut self.inst);
             let qubits =
@@ -62,13 +62,13 @@ impl<'a> Iterator for CircuitInstructions<'a> {
                 std::slice::from_raw_parts(self.inst.params, self.inst.num_params as usize);
             let c_name: Box<CStr> = Box::from(CStr::from_ptr(self.inst.name));
             let name = c_name.into_c_string().into_string().unwrap();
-            let out = Some(CircuitInstruction {
+
+            Some(CircuitInstruction {
                 name,
                 qubits,
                 clbits,
                 params,
-            });
-            out
+            })
         };
         self.index += 1;
         out

--- a/crates/client/src/qiskit_circuit.rs
+++ b/crates/client/src/qiskit_circuit.rs
@@ -31,7 +31,7 @@ pub struct CircuitInstructions<'a> {
 impl<'a> Drop for CircuitInstructions<'a> {
     fn drop(&mut self) {
         unsafe {
-            qiskit_ffi::qk_circuit_instruction_clear(&self.inst);
+            qiskit_ffi::qk_circuit_instruction_clear(&mut self.inst);
         }
     }
 }
@@ -51,7 +51,7 @@ impl<'a> Iterator for CircuitInstructions<'a> {
         }
         let out = unsafe {
             if self.index > 0 {
-                qiskit_ffi::qk_circuit_instruction_clear(&self.inst);
+                qiskit_ffi::qk_circuit_instruction_clear(&mut self.inst);
             }
             qiskit_ffi::qk_circuit_get_instruction(self.circuit.0, self.index, &mut self.inst);
             let qubits =

--- a/crates/client/src/qiskit_ffi.rs
+++ b/crates/client/src/qiskit_ffi.rs
@@ -206,7 +206,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     #[doc = " @ingroup QkCircuit\n Free a circuit instruction object\n\n @param inst The instruction to free\n\n # Safety\n Behavior is undefined if ``inst`` is not an object returned by ``qk_circuit_get_instruction``."]
-    pub fn qk_circuit_instruction_clear(inst: *const QkCircuitInstruction);
+    pub fn qk_circuit_instruction_clear(inst: *mut QkCircuitInstruction);
 }
 unsafe extern "C" {
     #[doc = " @ingroup QkCircuit\n Free a circuit op count list.\n\n @param op_counts The returned op count list from ``qk_circuit_count_ops``.\n\n # Safety\n\n Behavior is undefined if ``op_counts`` is not the object returned by ``qk_circuit_count_ops``."]

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -33,7 +33,6 @@ use ibmcloud_iam_api::models::token_response::TokenResponse;
 use crate::{log_debug, log_warn, ExitCode};
 use ibm_quantum_platform_api::models;
 use ibm_quantum_platform_api::models::job_response::Status;
-use ibm_quantum_platform_api::models::SamplerV2Result;
 use std::collections::HashMap;
 use std::error;
 use std::ffi::{c_char, CString};
@@ -496,7 +495,7 @@ pub async fn get_backend(service: &Service, backend: &Backend) -> crate::qiskit_
     let measure_props = backend_properties["qubits"]
         .as_array()
         .unwrap()
-        .into_iter()
+        .iter()
         .enumerate()
         .map(|(idx, props)| {
             let mut error = None;


### PR DESCRIPTION
This commit address most of the compiler warnings coming from the client crate. The generated code still has some warnings, but we should minimize the changes there as I expect we'll want to regenerate the bindings soon to get some fixes in recent updates. There are still warnings coming from unused structs or fields, but I don't think those are critical right now and we can address those in the future if needed.