### PR TITLE
Handle circuits with 0 clbits in qpy generation

### DIFF
--- a/crates/client/src/generate_qpy.rs
+++ b/crates/client/src/generate_qpy.rs
@@ -52,6 +52,8 @@ pub fn generate_qpy_payload(circuit: &qiskit_circuit::Circuit) -> BinResult<Vec<
             bit_indices: (0..circuit.num_clbits()).map(|x| x as i64).collect(),
         }]
     } else {
+        // Workaround for IBM Quantum Platform API error described at
+        // https://github.com/Qiskit/qiskit-ibm-runtime-c/pull/17
         vec![]
     };
     let circuit_header = qpy_formats::CircuitHeaderV12Pack {

--- a/crates/client/src/generate_qpy.rs
+++ b/crates/client/src/generate_qpy.rs
@@ -41,6 +41,19 @@ pub fn generate_qpy_payload(circuit: &qiskit_circuit::Circuit) -> BinResult<Vec<
     .write(&mut writer)?;
     qpy_formats::ProgramType { type_key: b'q' }.write(&mut writer)?;
     let empty_json = "{}";
+    let registers = if circuit.num_clbits() == 0 {
+        vec![qpy_formats::RegisterV4Pack {
+            register_type: b'c',
+            standalone: true as u8,
+            size: circuit.num_clbits(),
+            name_size: 4,
+            in_circuit: true as u8,
+            name: "meas".as_bytes().to_vec(),
+            bit_indices: (0..circuit.num_clbits()).map(|x| x as i64).collect(),
+        }]
+    } else {
+        vec![]
+    };
     let circuit_header = qpy_formats::CircuitHeaderV12Pack {
         name_size: 0,
         global_phase_type: b'f',
@@ -54,15 +67,7 @@ pub fn generate_qpy_payload(circuit: &qiskit_circuit::Circuit) -> BinResult<Vec<
         circuit_name: Vec::new(),
         global_phase_data: 0_f64.to_be_bytes().to_vec(),
         metadata: empty_json.as_bytes().to_vec(),
-        registers: vec![qpy_formats::RegisterV4Pack {
-            register_type: b'c',
-            standalone: true as u8,
-            size: circuit.num_clbits(),
-            name_size: 4,
-            in_circuit: true as u8,
-            name: "meas".as_bytes().to_vec(),
-            bit_indices: (0..circuit.num_clbits()).map(|x| x as i64).collect(),
-        }],
+        registers,
     };
     let instructions =
         circuit


### PR DESCRIPTION
Right now to ensure the sampler jobs function we need to set a classical register for the clbits. Currently the Qiskit C API doesn't have a way to query the registers in a circuit (see Qiskit/qiskit#15680 for the tracking issue) so this is a workaround until there is. However, when there are 0 classical bits in a circuit we still were creating a classical register for the qpy, resulting a zero sized classical register. Qiskit lets you create a zero sized register so it's valid, however submitting this to the IBM Quantum Platform API results in an internal error. To avoid the error this commit avoid creating the zero sized register in the outbound generated QPY so we just send a circuit without any clbits instead to the IBM Quantum API.