### PR TITLE
Add a method to copy the ExpectationValues into a double array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
         run: cmake --build build --config Release
       - name: Test
         run: ctest --test-dir build --output-on-failure -C Release
+      - name: Rust tests
+        run: cargo test

--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -374,6 +374,19 @@ pub unsafe extern "C" fn qkrt_expectation_values_get_ev(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn qkrt_expectation_values_copy_into(
+    evs: *const ExpectationValues,
+    out: *mut f64,
+) {
+    let evs = unsafe { const_ptr_as_ref(evs) };
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out, evs.0.len()) };
+    evs.0
+        .iter()
+        .zip(out_slice.iter_mut())
+        .for_each(|(src, dst)| *dst = *src);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn qkrt_str_free(string: *mut c_char) {
     let _ = CString::from_raw(string);
 }
@@ -428,4 +441,17 @@ pub extern "C" fn get_access_token() {
     let account = rt.block_on(get_account_from_config(None, None)).unwrap();
     println!("run");
     println!("token: {:?}", account.get_access_token());
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_copy_evs() {
+        let evs = ExpectationValues(vec![1.0, 0.0, -1.5]);
+        let mut out: Vec<f64> = vec![0.0; 3];
+        unsafe { qkrt_expectation_values_copy_into(&evs, out.as_mut_ptr()) };
+        assert_eq!(out, evs.0);
+    }
 }

--- a/crates/client/src/qiskit_observable.rs
+++ b/crates/client/src/qiskit_observable.rs
@@ -12,7 +12,6 @@
 
 use crate::qiskit_ffi;
 use std::collections::HashMap;
-use std::ffi::CString;
 
 pub struct BitTerm(pub *mut qiskit_ffi::QkBitTerm);
 pub struct SparseObservable(pub *mut qiskit_ffi::QkObs);
@@ -32,7 +31,7 @@ impl SparseObservable {
         (0..num_terms as u64)
             .map(|i| unsafe {
                 qiskit_ffi::qk_obs_term(self.0, i, term.as_mut_ptr());
-                let mut label = vec!['I' as u8; self.num_qubits() as usize];
+                let mut label = vec![b'I'; self.num_qubits() as usize];
                 let term = &*term.as_ptr();
                 let bit_terms = std::slice::from_raw_parts(term.bit_terms, term.len);
                 let indices = std::slice::from_raw_parts(term.indices, term.len);

--- a/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
+++ b/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
@@ -210,9 +210,23 @@ extern size_t qkrt_expectation_values_num_evs(ExpectationValues *evs);
  */
 extern char* qkrt_samples_get_sample(const Samples *samples, size_t index);
 
-
+/**
+ * Get a specified expectation value by index
+ * @param evs The handle of the expetation values returned from `qkrt_estimator_job_results`.
+ * @param index The index to get the expectation value of from `evs`.
+ */
 extern double qkrt_expectation_values_get_ev(ExpectationValues *evs, size_t index);
 
+/**
+ * Copy the expectation values into a double array.
+ *
+ * @param evs The handle to the expectation values from an estimator job
+ * @param out A pointer to the double array that the expectation values will be copied
+ *    into. The allocation this points to must have a sufficient space to store the
+ *    length of `evs`. You can use `qkrt_expectation_values_num_evs` to check the
+ *    length of `evs`.
+ */
+extern void qkrt_expectation_values_copy_into(ExpectationValues *evs, double *out);
 
 /**
  * Free the provided samples.


### PR DESCRIPTION
In some applications it's more useful to have all the expectation value in an owned double array on the caller side. We added the ExpectationValues type to the library to avoid a second allocation as the `Vec<f64>` would necessarily be allocated as part of deserializing the result JSON payload. However it is less ergonomic in many cases to work with the opaque type, so this commit adds a method to copy the resulting data into a array owned by the caller.