### PR TITLE
fix add-running-sampler-examples-instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ add_executable(test_lucj_fe4s4 samples/test_lucj_fe4s4.c)
 target_include_directories(test_lucj_fe4s4 PRIVATE ${PROJECT_INCLUDEDIR})
 target_link_libraries(test_lucj_fe4s4 PRIVATE qiskit qiskit_ibm_runtime)
 
+add_executable(test_error_handling_run samples/test_error_handling_run.c)
+target_include_directories(test_error_handling_run PRIVATE ${PROJECT_INCLUDEDIR})
+target_link_libraries(test_error_handling_run PRIVATE qiskit qiskit_ibm_runtime)
+
 # ---- Tests -------------------------------------------------------------------
 enable_testing()
 
@@ -128,11 +132,6 @@ add_executable(test_qpy tests/test_qpy.c)
 target_include_directories(test_qpy PRIVATE ${PROJECT_INCLUDEDIR})
 target_link_libraries(test_qpy PRIVATE qiskit qiskit_ibm_runtime)
 add_test(NAME qpy COMMAND test_qpy)
-
-add_executable(test_error_handling_run samples/test_error_handling_run.c)
-target_include_directories(test_error_handling_run PRIVATE ${PROJECT_INCLUDEDIR})
-target_link_libraries(test_error_handling_run PRIVATE qiskit qiskit_ibm_runtime)
-add_test(NAME error_handling COMMAND test_error_handling_run)
 
 # ---- Notes -------------------------------------------------------------------
 message(STATUS "CMake build type: ${CMAKE_BUILD_TYPE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,11 @@ target_include_directories(test_qpy PRIVATE ${PROJECT_INCLUDEDIR})
 target_link_libraries(test_qpy PRIVATE qiskit qiskit_ibm_runtime)
 add_test(NAME qpy COMMAND test_qpy)
 
+add_executable(test_error_handling_run samples/test_error_handling_run.c)
+target_include_directories(test_error_handling_run PRIVATE ${PROJECT_INCLUDEDIR})
+target_link_libraries(test_error_handling_run PRIVATE qiskit qiskit_ibm_runtime)
+add_test(NAME error_handling COMMAND test_error_handling_run)
+
 # ---- Notes -------------------------------------------------------------------
 message(STATUS "CMake build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Cargo profile: ${CARGO_PROFILE}")

--- a/README.md
+++ b/README.md
@@ -54,19 +54,24 @@ ctest
 
 #### Running Sampler Examples
 
-Before running the sampler examples, you must first create a config json file with  IBM Quantum account credentials at your home root directory `$HOME/.qiskit/qiskit-ibm.json`
+Before running the sampler examples, you must first set your account credentials.
+* `token`: Your IBM Quantum account token
+* `instance`: Your IBM Quantum account instance
+* `channel`: Your IBM Quantum account channel (optional)
 
-##### Configuration Parameters
+##### Configuration Methods (in priority order)
 
-* `name`: Accepted examples `default-ibm-quantum-platform`, `defautt-ibm-cloud`, or `default`
-* `token`: Your IBM Quantum API token
-* `instance`: Quantum service instance CRN
-* `channel`: The channel of the IBM Quantum API
-* `url`: The url of the IBM Quantum API
+1. **Environment Variables** (recommended)
+   ```bash
+   export QISKIT_IBM_TOKEN="your_token"
+   export QISKIT_IBM_INSTANCE="your_instance"
+   export QISKIT_IBM_CHANNEL="ibm_quantum"  # optional
 
-##### Example of qiskit-ibm.json file:
+2. **Configuration File for local development**
 
-Create the file `$HOME/.qiskit/qiskit-ibm.json` with the following structure:
+Configuration File to be Created at `$HOME/.qiskit/qiskit-ibm.json` with IBM Quantum account credentials and the desired channel, at your home root directory.
+
+Example of qiskit-ibm.json file:
 
 ```json
 {
@@ -74,7 +79,6 @@ Create the file `$HOME/.qiskit/qiskit-ibm.json` with the following structure:
     "token": "YOUR_IBM_QUANTUM_TOKEN",
     "instance": "YOUR_INSTANCE_CRN",
     "channel": "ibm_quantum",
-    "url": "https://auth.quantum-computing.ibm.com/api"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,40 @@ To run all tests, you can run the following command from within the build tree,
 ctest
 ```
 
+#### Running Sampler Examples
+
+Before running the sampler examples, you must first create a config json file with  IBM Quantum account credentials at your home root directory `$HOME/.qiskit/qiskit-ibm.json`
+
+##### Configuration Parameters
+
+* `name`: Accepted examples `default-ibm-quantum-platform`, `defautt-ibm-cloud`, or `default`
+* `token`: Your IBM Quantum API token
+* `instance`: Quantum service instance CRN
+* `channel`: The channel of the IBM Quantum API
+* `url`: The url of the IBM Quantum API
+
+##### Example of qiskit-ibm.json file:
+
+Create the file `$HOME/.qiskit/qiskit-ibm.json` with the following structure:
+
+```json
+{
+  "default-ibm-quantum-platform": {
+    "token": "YOUR_IBM_QUANTUM_TOKEN",
+    "instance": "YOUR_INSTANCE_CRN",
+    "channel": "ibm_quantum",
+    "url": "https://auth.quantum-computing.ibm.com/api"
+  }
+}
+```
+
+More details how to set your account can be found [here](https://github.com/Qiskit/qiskit-ibm-runtime?tab=readme-ov-file#save-your-account-on-disk)
+
+##### Running the Examples
+
+After configuring your account, execute the sampler examples as `./test_ghz_sampler_run`
+
+
 #### License
 
 This software is licensed under the Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Before running the sampler examples, you must first set your account credentials
    export QISKIT_IBM_TOKEN="your_token"
    export QISKIT_IBM_INSTANCE="your_instance"
    export QISKIT_IBM_CHANNEL="ibm_quantum"  # optional
+   ```
 
 2. **Configuration File for local development**
 
@@ -78,7 +79,7 @@ Example of qiskit-ibm.json file:
   "default-ibm-quantum-platform": {
     "token": "YOUR_IBM_QUANTUM_TOKEN",
     "instance": "YOUR_INSTANCE_CRN",
-    "channel": "ibm_quantum",
+    "channel": "ibm_quantum"
   }
 }
 ```

--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -21,6 +21,7 @@ use std::ffi::{c_char, CStr, CString};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
+use std::cell::RefCell;
 
 use crate::service::{
     get_account_from_config, get_backend, get_backends, get_estimator_job_results, get_job_details,
@@ -29,16 +30,38 @@ use crate::service::{
     Service,
 };
 
+thread_local! {
+    static LAST_ERROR: RefCell<Option<CString>> = RefCell::new(None);
+}
+
+pub(crate) fn set_last_error(message: String) {
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = CString::new(message).ok();
+    });
+}
+
 macro_rules! check_result {
     ($expr:expr) => {
         match $expr {
             Ok(val) => val,
             Err(e) => {
-                log_err(&format!("{:?}", &e));
+                let error_msg = format!("{}", &e);
+                log_err(&format!("{}", &e));
+                crate::c_api::set_last_error(error_msg); 
                 return e.code();
             }
         }
     };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn qkrt_get_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow()
+            .as_ref()
+            .map(|s| s.as_ptr())
+            .unwrap_or(std::ptr::null())
+    })
 }
 
 /// This function only generates ISA static circuit QPY with no parameters

--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -46,7 +46,7 @@ macro_rules! check_result {
             Ok(val) => val,
             Err(e) => {
                 let error_msg = format!("{}", &e);
-                log_err(&format!("{}", &e));
+                log_err(&error_msg);
                 crate::c_api::set_last_error(error_msg); 
                 return e.code();
             }

--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -31,12 +31,12 @@ use crate::service::{
 };
 
 thread_local! {
-    static LAST_ERROR: RefCell<Option<CString>> = RefCell::new(None);
+    static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
 }
 
 pub(crate) fn set_last_error(message: String) {
     LAST_ERROR.with(|e| {
-        *e.borrow_mut() = CString::new(message).ok();
+        *e.borrow_mut() = Some(message);
     });
 }
 
@@ -55,12 +55,13 @@ macro_rules! check_result {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn qkrt_get_last_error() -> *const c_char {
+pub unsafe extern "C" fn qkrt_get_last_error() -> *mut c_char {
     LAST_ERROR.with(|e| {
         e.borrow()
             .as_ref()
-            .map(|s| s.as_ptr())
-            .unwrap_or(std::ptr::null())
+            .and_then(|msg| CString::new(msg.as_str()).ok())
+            .map(|cstr| cstr.into_raw())
+            .unwrap_or(std::ptr::null_mut())
     })
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -79,19 +79,19 @@ pub enum ExitCode {
     IAMAPIConflict = 305,
     
     /// Configuration error (missing or invalid credentials/config file).
-    ConfigurationError = 400,
+    ConfigurationError = 601,
     /// Configuration error - home directory not found.
-    ConfigHomeDirectoryNotFound = 401,
+    ConfigHomeDirectoryNotFound = 602,
     /// Configuration error - config file not found.
-    ConfigFileNotFound = 402,
+    ConfigFileNotFound = 603,
     /// Configuration error - invalid JSON in config file.
-    ConfigInvalidJson = 403,
+    ConfigInvalidJson = 604,
     /// Configuration error - specified account not found.
-    ConfigAccountNotFound = 404,
+    ConfigAccountNotFound = 605,
     /// Configuration error - no default account configured.
-    ConfigNoDefaultAccount = 405,
+    ConfigNoDefaultAccount = 606,
     /// Configuration error - missing credentials.
-    ConfigMissingCredentials = 406,
+    ConfigMissingCredentials = 607,
 }
 
 fn log_err(e: &impl AsRef<str>) {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -77,6 +77,21 @@ pub enum ExitCode {
     IAMAPINotFound = 304,
     /// The IBM IAM returned a 409.
     IAMAPIConflict = 305,
+    
+    /// Configuration error (missing or invalid credentials/config file).
+    ConfigurationError = 400,
+    /// Configuration error - home directory not found.
+    ConfigHomeDirectoryNotFound = 401,
+    /// Configuration error - config file not found.
+    ConfigFileNotFound = 402,
+    /// Configuration error - invalid JSON in config file.
+    ConfigInvalidJson = 403,
+    /// Configuration error - specified account not found.
+    ConfigAccountNotFound = 404,
+    /// Configuration error - no default account configured.
+    ConfigNoDefaultAccount = 405,
+    /// Configuration error - missing credentials.
+    ConfigMissingCredentials = 406,
 }
 
 fn log_err(e: &impl AsRef<str>) {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -78,20 +78,18 @@ pub enum ExitCode {
     /// The IBM IAM returned a 409.
     IAMAPIConflict = 305,
     
-    /// Configuration error (missing or invalid credentials/config file).
-    ConfigurationError = 601,
-    /// Configuration error - home directory not found.
-    ConfigHomeDirectoryNotFound = 602,
-    /// Configuration error - config file not found.
-    ConfigFileNotFound = 603,
-    /// Configuration error - invalid JSON in config file.
-    ConfigInvalidJson = 604,
-    /// Configuration error - specified account not found.
-    ConfigAccountNotFound = 605,
-    /// Configuration error - no default account configured.
-    ConfigNoDefaultAccount = 606,
     /// Configuration error - missing credentials.
-    ConfigMissingCredentials = 607,
+    ConfigMissingCredentials = 400,
+    /// Configuration error - home directory not found.
+    ConfigHomeDirectoryNotFound = 401,
+    /// Configuration error - config file not found.
+    ConfigFileNotFound = 403,
+    /// Configuration error - specified account not found.
+    ConfigAccountNotFound = 404,
+    /// Configuration error - invalid JSON in config file.
+    ConfigInvalidJson = 405,
+    /// Configuration error - no default account configured.
+    ConfigNoDefaultAccount = 406,
 }
 
 fn log_err(e: &impl AsRef<str>) {

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -236,9 +236,7 @@ fn get_account_config(filename: Option<&str>, name: Option<&str>) -> Result<Acco
     if let Ok(token) = std::env::var("QISKIT_IBM_TOKEN") {
 
         let instance = std::env::var("QISKIT_IBM_INSTANCE")
-            .map_err(|_| ConfigError::MissingCredentials)?; //{
-                //var_name: "QISKIT_IBM_INSTANCE".to_string(),
-        //})?;
+            .map_err(|_| ConfigError::MissingCredentials)?; 
 
         return Ok(AccountEntry {
             token,

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -243,7 +243,7 @@ fn get_account_config(filename: Option<&str>, name: Option<&str>) -> Result<Acco
         return Ok(AccountEntry {
             token,
             instance: Some(instance),
-            channel: std::env::var("QISKIT_IBM_CHANNEL").unwrap_or_else(|_| "ibm-quantum".to_string()),
+            channel: std::env::var("QISKIT_IBM_CHANNEL").unwrap_or_else(|_| "ibm_quantum".to_string()),
             url: std::env::var("QISKIT_IBM_URL").unwrap_or_else(|_| "https://auth.quantum-computing.ibm.com/api".to_string()),
             verify: true,
             private_endpoint: false,

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -231,28 +231,210 @@ impl<T: Debug> From<ibmcloud_iam_api::apis::Error<T>> for ServiceError {
     }
 }
 
-fn get_account_config(filename: Option<&str>, name: Option<&str>) -> AccountEntry {
+
+fn get_account_config(filename: Option<&str>, name: Option<&str>) -> Result<AccountEntry, ConfigError> {
+    if let Ok(token) = std::env::var("QISKIT_IBM_TOKEN") {
+
+        let instance = std::env::var("QISKIT_IBM_INSTANCE")
+            .map_err(|_| ConfigError::MissingRequiredEnvVar {
+                var_name: "QISKIT_IBM_INSTANCE".to_string(),
+        })?;
+
+        return Ok(AccountEntry {
+            token,
+            instance: Some(instance),
+            channel: std::env::var("QISKIT_IBM_CHANNEL").unwrap_or_else(|_| "ibm-quantum".to_string()),
+            url: std::env::var("QISKIT_IBM_URL").unwrap_or_else(|_| "https://auth.quantum-computing.ibm.com/api".to_string()),
+            verify: true,
+            private_endpoint: false,
+            proxies: None,
+        });
+    }
+
     let filename = match filename {
         Some(path) => path.to_string(),
         None => {
-            let home = std::env::var("HOME").unwrap();
+            let home = std::env::var("HOME").map_err(|_| ConfigError::HomeDirectoryNotFound)?;
             format!("{}/.qiskit/qiskit-ibm.json", home)
         }
     };
+
     let file_path = Path::new(&filename);
 
-    let file = File::open(file_path).unwrap();
+    let file = File::open(file_path).map_err(|e| ConfigError::FileNotFound {
+        path: filename.clone(),
+        error: e.to_string(), 
+    })?;
+
     let reader = BufReader::new(file);
-    let accounts: HashMap<String, AccountEntry> = serde_json::from_reader(reader).unwrap();
+    let accounts: HashMap<String, AccountEntry> = serde_json::from_reader(reader)
+     .map_err(|e| ConfigError::InvalidJson {
+        path: filename.clone(),
+        error: e.to_string(),
+    })?;
+
     match name {
-        Some(name) => accounts[name].clone(),
-        None => accounts
+        Some(name) => { accounts.get(name)
+            .cloned()
+            .ok_or_else(|| ConfigError::AccountNotFound {
+                name: name.to_string(),
+                available: accounts.keys().cloned().collect(),
+            })
+        }
+        None => { accounts
             .get("default")
             .or_else(|| accounts.get("default-ibm-quantum-platform"))
-            .unwrap_or_else(|| &accounts["default-ibm-cloud"])
-            .clone(),
+            .or_else(|| accounts.get("default-ibm-cloud"))
+            .cloned()
+            .ok_or((|| ConfigError::NoDefaultAccount {
+                available: accounts.keys().cloned().collect(),
+            })())
+        }    
     }
 }
+
+
+#[derive(Debug)]
+pub enum ConfigError {
+    HomeDirectoryNotFound,
+    FileNotFound { path: String, error: String },
+    InvalidJson { path: String, error: String },
+    AccountNotFound { name: String, available: Vec<String> },
+    NoDefaultAccount { available: Vec<String> },
+    MissingCredentials,
+    MissingRequiredEnvVar { var_name: String }, 
+}
+
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ConfigError::HomeDirectoryNotFound => {
+                write!(f, "[CONFIG ERROR] Could not determine home directory.\n\
+                    \nTroubleshooting:\n\
+                    - Ensure HOME environment variable is set\n\
+                    - Or use QISKIT_IBM_TOKEN environment variable instead")
+            }
+            ConfigError::FileNotFound { path, error } => {
+                write!(f, "[CONFIG ERROR] Configuration file not found\n\
+                    \nFile: {}\n\
+                    Error: {}\n\
+                    \nSolutions:\n\
+                    1. Set environment variables:\n\
+                       export QISKIT_IBM_TOKEN=\"your_token\"\n\
+                       export QISKIT_IBM_INSTANCE=\"your_instance\"\n\
+                    2. Create config file at: ~/.qiskit/qiskit-ibm.json\n\
+                       See: https://github.com/Qiskit/qiskit-ibm-runtime#configuration",
+                    path, error)
+            }
+            ConfigError::InvalidJson { path, error } => {
+                write!(f, "[CONFIG ERROR] Invalid JSON in configuration file\n\
+                    \nFile: {}\n\
+                    Parse error: {}\n\
+                    \nPlease check your JSON syntax at: {}",
+                    path, error, path)
+            }
+            ConfigError::AccountNotFound { name, available } => {
+                write!(f, "[CONFIG ERROR] Account '{}' not found in configuration\n\
+                    \nAvailable accounts: {:?}\n\
+                    \nPlease use one of the available account names or add '{}' to your config file.",
+                    name, available, name)
+            }
+            ConfigError::NoDefaultAccount { available } => {
+                write!(f, "[CONFIG ERROR] No default account found in configuration\n\
+                    \nAvailable accounts: {:?}\n\
+                    \nExpected one of:\n\
+                    - 'default'\n\
+                    - 'default-ibm-quantum-platform'\n\
+                    - 'default-ibm-cloud'\n\
+                    \nPlease rename one of your accounts to a default name.",
+                    available)
+            }
+            ConfigError::MissingCredentials => {
+                write!(f, "[CONFIG ERROR] No credentials found\n\
+                    \nPlease provide credentials using either:\n\
+                    1. Environment variables:\n\
+                       export QISKIT_IBM_TOKEN=\"your_token\"\n\
+                       export QISKIT_IBM_INSTANCE=\"your_instance\"\n\
+                    2. Configuration file at ~/.qiskit/qiskit-ibm.json")
+            }
+            ConfigError::MissingRequiredEnvVar { var_name } => {
+                write!(f, "[CONFIG ERROR] Missing required environment variable: {}\n\
+                    \nWhen using QISKIT_IBM_TOKEN, you must also set:\n\
+                    export {}=\"your_value\"\n\
+                    \nAlternatively, use a configuration file at ~/.qiskit/qiskit-ibm.json",
+                    var_name, var_name)
+            }
+        }
+    }
+}
+
+
+impl From<ConfigError> for ServiceError {
+    fn from(value: ConfigError) -> Self {
+        match value {
+            ConfigError::HomeDirectoryNotFound => ServiceError {
+                code: ExitCode::ConfigHomeDirectoryNotFound,
+                message: "Could not determine home directory.\n\
+                    \nTroubleshooting:\n\
+                    - Ensure HOME environment variable is set\n\
+                    - Or use QISKIT_IBM_TOKEN environment variable instead".to_string(),
+            },
+            ConfigError::FileNotFound { path, error } => ServiceError {
+                code: ExitCode::ConfigFileNotFound,
+                message: format!(
+                    "Configuration file not found at '{}': {}\n\
+                    \nPlease either:\n\
+                    1. Set environment variables: QISKIT_IBM_TOKEN, QISKIT_IBM_INSTANCE\n\
+                    2. Create config file at: ~/.qiskit/qiskit-ibm.json",
+                    path, error
+                ),
+            },
+            ConfigError::InvalidJson { path, error } => ServiceError {
+                code: ExitCode::ConfigInvalidJson,
+                message: format!(
+                    "Invalid JSON in config file '{}':\n{}\n\
+                    \nPlease check your JSON syntax.",
+                    path, error
+                ),
+            },
+            ConfigError::AccountNotFound { name, available } => ServiceError {
+                code: ExitCode::ConfigAccountNotFound,
+                message: format!(
+                    "Account '{}' not found in configuration.\n\
+                    \nAvailable accounts: {:?}\n\
+                    \nPlease use one of the available account names.",
+                    name, available
+                ),
+            },
+            ConfigError::NoDefaultAccount { available } => ServiceError {
+                code: ExitCode::ConfigNoDefaultAccount,
+                message: format!(
+                    "No default account found in configuration.\n\
+                    \nAvailable accounts: {:?}\n\
+                    \nExpected one of: 'default', 'default-ibm-quantum-platform', 'default-ibm-cloud'",
+                    available
+                ),
+            },
+            ConfigError::MissingCredentials => ServiceError {
+                code: ExitCode::ConfigMissingCredentials,
+                message: "No credentials found.\n\
+                    \nPlease set QISKIT_IBM_TOKEN environment variable or create ~/.qiskit/qiskit-ibm.json".to_string(),
+            },
+            ConfigError::MissingRequiredEnvVar { var_name } => ServiceError {
+                code: ExitCode::ConfigMissingCredentials,
+                message: format!(
+                    "Missing required environment variable: {}\n\
+                    \nWhen using QISKIT_IBM_TOKEN, you must also set:\n\
+                    export {}=\"your_value\"\n\
+                    \nAlternatively, use a configuration file at ~/.qiskit/qiskit-ibm.json",
+                    var_name, var_name
+                ),
+            },
+        }
+    }
+}
+
 
 #[derive(Clone, Debug)]
 pub struct Service {
@@ -302,7 +484,8 @@ pub async fn get_account_from_config(
     filename: Option<&str>,
     name: Option<&str>,
 ) -> Result<Account, ServiceError> {
-    let config = get_account_config(filename, name);
+    let config = get_account_config(filename, name)?;
+
     let iam_config = Configuration {
         base_path: "https://iam.cloud.ibm.com".to_owned(),
         user_agent: Some("qiskit-ibm-runtime-rs/0.0.1".to_owned()),

--- a/crates/client/src/service.rs
+++ b/crates/client/src/service.rs
@@ -236,9 +236,9 @@ fn get_account_config(filename: Option<&str>, name: Option<&str>) -> Result<Acco
     if let Ok(token) = std::env::var("QISKIT_IBM_TOKEN") {
 
         let instance = std::env::var("QISKIT_IBM_INSTANCE")
-            .map_err(|_| ConfigError::MissingRequiredEnvVar {
-                var_name: "QISKIT_IBM_INSTANCE".to_string(),
-        })?;
+            .map_err(|_| ConfigError::MissingCredentials)?; //{
+                //var_name: "QISKIT_IBM_INSTANCE".to_string(),
+        //})?;
 
         return Ok(AccountEntry {
             token,
@@ -286,9 +286,9 @@ fn get_account_config(filename: Option<&str>, name: Option<&str>) -> Result<Acco
             .or_else(|| accounts.get("default-ibm-quantum-platform"))
             .or_else(|| accounts.get("default-ibm-cloud"))
             .cloned()
-            .ok_or((|| ConfigError::NoDefaultAccount {
+            .ok_or_else(|| ConfigError::NoDefaultAccount {
                 available: accounts.keys().cloned().collect(),
-            })())
+            })
         }    
     }
 }
@@ -296,13 +296,12 @@ fn get_account_config(filename: Option<&str>, name: Option<&str>) -> Result<Acco
 
 #[derive(Debug)]
 pub enum ConfigError {
+    MissingCredentials,
     HomeDirectoryNotFound,
     FileNotFound { path: String, error: String },
     InvalidJson { path: String, error: String },
     AccountNotFound { name: String, available: Vec<String> },
     NoDefaultAccount { available: Vec<String> },
-    MissingCredentials,
-    MissingRequiredEnvVar { var_name: String }, 
 }
 
 
@@ -357,13 +356,6 @@ impl std::fmt::Display for ConfigError {
                        export QISKIT_IBM_TOKEN=\"your_token\"\n\
                        export QISKIT_IBM_INSTANCE=\"your_instance\"\n\
                     2. Configuration file at ~/.qiskit/qiskit-ibm.json")
-            }
-            ConfigError::MissingRequiredEnvVar { var_name } => {
-                write!(f, "[CONFIG ERROR] Missing required environment variable: {}\n\
-                    \nWhen using QISKIT_IBM_TOKEN, you must also set:\n\
-                    export {}=\"your_value\"\n\
-                    \nAlternatively, use a configuration file at ~/.qiskit/qiskit-ibm.json",
-                    var_name, var_name)
             }
         }
     }
@@ -420,16 +412,6 @@ impl From<ConfigError> for ServiceError {
                 code: ExitCode::ConfigMissingCredentials,
                 message: "No credentials found.\n\
                     \nPlease set QISKIT_IBM_TOKEN environment variable or create ~/.qiskit/qiskit-ibm.json".to_string(),
-            },
-            ConfigError::MissingRequiredEnvVar { var_name } => ServiceError {
-                code: ExitCode::ConfigMissingCredentials,
-                message: format!(
-                    "Missing required environment variable: {}\n\
-                    \nWhen using QISKIT_IBM_TOKEN, you must also set:\n\
-                    export {}=\"your_value\"\n\
-                    \nAlternatively, use a configuration file at ~/.qiskit/qiskit-ibm.json",
-                    var_name, var_name
-                ),
             },
         }
     }

--- a/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
+++ b/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
@@ -241,4 +241,4 @@ extern void qkrt_str_free(char *string);
  * @return Pointer to null-terminated error message string, or NULL if no error.
  *         The pointer is valid until the next error occurs or the thread exits.
  */
-const char* qkrt_get_last_error(void);
+ extern const char* qkrt_get_last_error(void);

--- a/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
+++ b/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
@@ -234,3 +234,11 @@ extern void qkrt_expectation_values_free(ExpectationValues *evs);
  * @param The string to free.
  */
 extern void qkrt_str_free(char *string);
+
+/**
+ * Get the last error message from the Rust library.
+ * 
+ * @return Pointer to null-terminated error message string, or NULL if no error.
+ *         The pointer is valid until the next error occurs or the thread exits.
+ */
+const char* qkrt_get_last_error(void);

--- a/samples/test_error_handling_run.c
+++ b/samples/test_error_handling_run.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
         printf("    }\n");
         printf("  }\n");
         printf("  EOF\n");
-        printf("  ./test_error_handling\n\n");
+        printf("  ./test_error_handling_run\n\n");
         
         return res;
     }

--- a/samples/test_error_handling_run.c
+++ b/samples/test_error_handling_run.c
@@ -38,6 +38,7 @@ void print_error(const char* context, int code) {
     const char* error_msg = qkrt_get_last_error();
     if (error_msg != NULL && error_msg[0] != '\0') {
         fprintf(stderr, "Error details:\n%s\n", error_msg);
+        qkrt_str_free(error_msg);
     } else {
         fprintf(stderr, "No detailed error message available.\n");
     }

--- a/samples/test_error_handling_run.c
+++ b/samples/test_error_handling_run.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <inttypes.h> 
 
 #include <qiskit_ibm_runtime/qiskit_ibm_runtime.h>
 
@@ -29,8 +30,6 @@
  * 2. Missing QISKIT_IBM_INSTANCE when QISKIT_IBM_TOKEN is set
  * 3. Invalid config file
  */
-
-extern const char* qkrt_get_last_error(void);
 
 void print_error(const char* context, int code) {
     fprintf(stderr, "\n=== Error in %s ===\n", context);
@@ -96,15 +95,15 @@ int main(int argc, char *argv[]) {
     }
     
     uint64_t result_count = qkrt_backend_search_results_length(results);
-    printf("✓ Found %llu backend(s)\n\n", result_count);
+    printf("✓ Found %" PRIu64 " backend(s)\n\n", result_count);
     
     if (result_count > 0) {
         Backend **backends = qkrt_backend_search_results_data(results);
         printf("Available backends:\n");
         for (uint64_t i = 0; i < result_count; i++) {
-            printf("  [%llu] %s\n", i, qkrt_backend_name(backends[i]));
+            printf("  [%" PRIu64 "] %s\n", i, qkrt_backend_name(backends[i]));
         }
-    }
+    }    
     
     qkrt_backend_search_results_free(results);
     qkrt_service_free(service);

--- a/samples/test_error_handling_run.c
+++ b/samples/test_error_handling_run.c
@@ -1,0 +1,116 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include <qiskit.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <qiskit_ibm_runtime/qiskit_ibm_runtime.h>
+
+/**
+ * Test program to verify error message handling.
+ * 
+ * This program intentionally triggers configuration errors to test
+ * that error messages are properly displayed.
+ * 
+ * Test scenarios:
+ * 1. No credentials (neither env vars nor config file)
+ * 2. Missing QISKIT_IBM_INSTANCE when QISKIT_IBM_TOKEN is set
+ * 3. Invalid config file
+ */
+
+extern const char* qkrt_get_last_error(void);
+
+void print_error(const char* context, int code) {
+    fprintf(stderr, "\n=== Error in %s ===\n", context);
+    fprintf(stderr, "Error code: %d\n", code);
+    
+    const char* error_msg = qkrt_get_last_error();
+    if (error_msg != NULL && error_msg[0] != '\0') {
+        fprintf(stderr, "Error details:\n%s\n", error_msg);
+    } else {
+        fprintf(stderr, "No detailed error message available.\n");
+    }
+    fprintf(stderr, "=========================\n\n");
+}
+
+int main(int argc, char *argv[]) {
+    printf("=== Qiskit IBM Runtime Error Handling Test ===\n\n");
+    
+    printf("Test 1: Attempting to create service...\n");
+    Service *service = NULL;
+    int res = qkrt_service_new(&service);
+    
+    if (res != 0) {
+        print_error("Service Creation", res);
+        printf("This is expected if:\n");
+        printf("  - No QISKIT_IBM_TOKEN environment variable is set\n");
+        printf("  - No ~/.qiskit/qiskit-ibm.json config file exists\n");
+        printf("  - QISKIT_IBM_TOKEN is set but QISKIT_IBM_INSTANCE is missing\n\n");
+        
+        printf("To fix this error, do one of the following:\n\n");
+        printf("Option 1 - Use environment variables:\n");
+        printf("  export QISKIT_IBM_TOKEN=\"your_token_here\"\n");
+        printf("  export QISKIT_IBM_INSTANCE=\"your_instance_here\"\n");
+        printf("  ./test_error_handling\n\n");
+        
+        printf("Option 2 - Create config file:\n");
+        printf("  mkdir -p ~/.qiskit\n");
+        printf("  cat > ~/.qiskit/qiskit-ibm.json << 'EOF'\n");
+        printf("  {\n");
+        printf("    \"default\": {\n");
+        printf("      \"token\": \"your_token_here\",\n");
+        printf("      \"instance\": \"your_instance_here\",\n");
+        printf("      \"channel\": \"ibm_quantum\",\n");
+        printf("      \"url\": \"https://auth.quantum-computing.ibm.com/api\"\n");
+        printf("    }\n");
+        printf("  }\n");
+        printf("  EOF\n");
+        printf("  ./test_error_handling\n\n");
+        
+        return res;
+    }
+    
+    printf("✓ Service created successfully!\n");
+    printf("This means your credentials are properly configured.\n\n");
+    
+    printf("Test 2: Attempting to search backends...\n");
+    BackendSearchResults *results = NULL;
+    res = qkrt_backend_search(&results, service);
+    
+    if (res != 0) {
+        print_error("Backend Search", res);
+        qkrt_service_free(service);
+        return res;
+    }
+    
+    uint64_t result_count = qkrt_backend_search_results_length(results);
+    printf("✓ Found %llu backend(s)\n\n", result_count);
+    
+    if (result_count > 0) {
+        Backend **backends = qkrt_backend_search_results_data(results);
+        printf("Available backends:\n");
+        for (uint64_t i = 0; i < result_count; i++) {
+            printf("  [%llu] %s\n", i, qkrt_backend_name(backends[i]));
+        }
+    }
+    
+    qkrt_backend_search_results_free(results);
+    qkrt_service_free(service);
+    
+    printf("\n=== All tests passed! ===\n");
+    printf("Your configuration is working correctly.\n");
+    
+    return 0;
+}

--- a/samples/test_ghz_estimator_run.c
+++ b/samples/test_ghz_estimator_run.c
@@ -18,6 +18,16 @@
 
 #include <qiskit_ibm_runtime/qiskit_ibm_runtime.h>
 
+extern const char* qkrt_get_last_error(void);
+
+void print_error_with_details(const char* context, int code) {
+    fprintf(stderr, "\n%s failed with code: %d\n", context, code);
+    const char* error_msg = qkrt_get_last_error();
+    if (error_msg != NULL && error_msg[0] != '\0') {
+        fprintf(stderr, "Details: %s\n", error_msg);
+    }
+}
+
 int main(int argc, char *arv[]) {
     // Build a 5 qubit GHZ state
     QkCircuit *qc = qk_circuit_new(5, 5);
@@ -37,14 +47,16 @@ int main(int argc, char *arv[]) {
     Service *service;
     res = qkrt_service_new(&service);
     if (res != 0) {
-        printf("service new failed with code: %d\n", res);
+        //printf("service new failed with code: %d\n", res);
+        print_error_with_details("service new", res);
         goto cleanup;
     }
 
     BackendSearchResults *results;
     res = qkrt_backend_search(&results, service);
     if (res != 0) {
-        printf("backend search failed with code: %d\n", res);
+        //printf("backend search failed with code: %d\n", res);
+        print_error_with_details("backend search", res);
         goto cleanup_service;
     }
     uint64_t result_count = qkrt_backend_search_results_length(results);
@@ -85,7 +97,8 @@ int main(int argc, char *arv[]) {
     Job *job;
     res = qkrt_estimator_job_run(&job, service, backends[selected_backend], transpile_result.circuit, obs, NULL);
     if (res != 0) {
-        printf("job submit failed with code: %d\n", res);
+        //printf("job submit failed with code: %d\n", res);
+        print_error_with_details("job submit", res);
         goto cleanup_search;
     }
     printf("job submit successful!\n");
@@ -95,7 +108,8 @@ int main(int argc, char *arv[]) {
         sleep(20);
         res = qkrt_job_status(&status, service, job);
         if (res != 0) {
-            printf("status poll failed with code: %d\n", res);
+            //printf("status poll failed with code: %d\n", res);
+            print_error_with_details("status poll", res);
             goto cleanup;
         }
         printf("current status: %d\n", status);

--- a/samples/test_ghz_estimator_run.c
+++ b/samples/test_ghz_estimator_run.c
@@ -18,8 +18,6 @@
 
 #include <qiskit_ibm_runtime/qiskit_ibm_runtime.h>
 
-extern const char* qkrt_get_last_error(void);
-
 void print_error_with_details(const char* context, int code) {
     fprintf(stderr, "\n%s failed with code: %d\n", context, code);
     const char* error_msg = qkrt_get_last_error();

--- a/samples/test_ghz_estimator_run.c
+++ b/samples/test_ghz_estimator_run.c
@@ -23,6 +23,7 @@ void print_error_with_details(const char* context, int code) {
     const char* error_msg = qkrt_get_last_error();
     if (error_msg != NULL && error_msg[0] != '\0') {
         fprintf(stderr, "Details: %s\n", error_msg);
+        qkrt_str_free(error_msg);
     }
 }
 

--- a/samples/test_ghz_estimator_run.c
+++ b/samples/test_ghz_estimator_run.c
@@ -47,7 +47,6 @@ int main(int argc, char *arv[]) {
     Service *service;
     res = qkrt_service_new(&service);
     if (res != 0) {
-        //printf("service new failed with code: %d\n", res);
         print_error_with_details("service new", res);
         goto cleanup;
     }
@@ -55,7 +54,6 @@ int main(int argc, char *arv[]) {
     BackendSearchResults *results;
     res = qkrt_backend_search(&results, service);
     if (res != 0) {
-        //printf("backend search failed with code: %d\n", res);
         print_error_with_details("backend search", res);
         goto cleanup_service;
     }
@@ -97,7 +95,6 @@ int main(int argc, char *arv[]) {
     Job *job;
     res = qkrt_estimator_job_run(&job, service, backends[selected_backend], transpile_result.circuit, obs, NULL);
     if (res != 0) {
-        //printf("job submit failed with code: %d\n", res);
         print_error_with_details("job submit", res);
         goto cleanup_search;
     }
@@ -108,7 +105,6 @@ int main(int argc, char *arv[]) {
         sleep(20);
         res = qkrt_job_status(&status, service, job);
         if (res != 0) {
-            //printf("status poll failed with code: %d\n", res);
             print_error_with_details("status poll", res);
             goto cleanup;
         }

--- a/samples/test_ghz_sampler_run.c
+++ b/samples/test_ghz_sampler_run.c
@@ -18,6 +18,16 @@
 
 #include <qiskit_ibm_runtime/qiskit_ibm_runtime.h>
 
+extern const char* qkrt_get_last_error(void);
+
+void print_error_with_details(const char* context, int code) {
+    fprintf(stderr, "\n%s failed with code: %d\n", context, code);
+    const char* error_msg = qkrt_get_last_error();
+    if (error_msg != NULL && error_msg[0] != '\0') {
+        fprintf(stderr, "Details: %s\n", error_msg);
+    }
+}
+
 int main(int argc, char *arv[]) {
     // Build a 5 qubit GHZ state
     QkCircuit *qc = qk_circuit_new(5, 5);
@@ -37,14 +47,14 @@ int main(int argc, char *arv[]) {
     Service *service;
     res = qkrt_service_new(&service);
     if (res != 0) {
-        printf("service new failed with code: %d\n", res);
+        print_error_with_details("service new", res);
         goto cleanup;
     }
 
     BackendSearchResults *results;
     res = qkrt_backend_search(&results, service);
     if (res != 0) {
-        printf("backend search failed with code: %d\n", res);
+        print_error_with_details("backend search", res);
         goto cleanup_service;
     }
     uint64_t result_count = qkrt_backend_search_results_length(results);
@@ -78,7 +88,7 @@ int main(int argc, char *arv[]) {
     Job *job;
     res = qkrt_sampler_job_run(&job, service, backends[selected_backend], transpile_result.circuit, shots, NULL);
     if (res != 0) {
-        printf("job submit failed with code: %d\n", res);
+        print_error_with_details("job submit", res);
         goto cleanup_search;
     }
     printf("job submit successful!\n");
@@ -88,7 +98,7 @@ int main(int argc, char *arv[]) {
         sleep(20);
         res = qkrt_job_status(&status, service, job);
         if (res != 0) {
-            printf("status poll failed with code: %d\n", res);
+            print_error_with_details("status poll", res);
             goto cleanup;
         }
         printf("current status: %d\n", status);

--- a/samples/test_ghz_sampler_run.c
+++ b/samples/test_ghz_sampler_run.c
@@ -18,8 +18,6 @@
 
 #include <qiskit_ibm_runtime/qiskit_ibm_runtime.h>
 
-extern const char* qkrt_get_last_error(void);
-
 void print_error_with_details(const char* context, int code) {
     fprintf(stderr, "\n%s failed with code: %d\n", context, code);
     const char* error_msg = qkrt_get_last_error();

--- a/samples/test_ghz_sampler_run.c
+++ b/samples/test_ghz_sampler_run.c
@@ -23,6 +23,7 @@ void print_error_with_details(const char* context, int code) {
     const char* error_msg = qkrt_get_last_error();
     if (error_msg != NULL && error_msg[0] != '\0') {
         fprintf(stderr, "Details: %s\n", error_msg);
+        qkrt_str_free(error_msg);
     }
 }
 


### PR DESCRIPTION
Update the readme with instructions of what to do before running the sampler examples.
This will eliminate the error message, because the configuration file is required. Must be added in the your home directory with account information.

**Implements proper error handling for configuration loading:**
- Environment variables (QISKIT_IBM_TOKEN, QISKIT_IBM_INSTANCE) now take priority over JSON config
- Added ConfigError enum with detailed, actionable error messages
- Added qkrt_get_last_error() to expose error messages to C code
- Updated check_result! macro to store error messages
- Added specific exit codes (401-406) for different configuration errors
- Updated test examples to display full error details
- Add a new sample test test_error_handling_run which verify the current status of the configuration 

Fixes [#128](https://github.com/Qiskit/qiskit-cpp/issues/128)