### PR TITLE
Add support for tags in jobs

### DIFF
--- a/crates/client/src/c_api.rs
+++ b/crates/client/src/c_api.rs
@@ -67,6 +67,7 @@ pub unsafe extern "C" fn qkrt_sampler_job_write_payload(
     backend: *const c_char,
     runtime: *const c_char,
     filename: *const c_char,
+    tags: *const *const c_char,
 ) {
     let circuit = Circuit(circuit);
     let path = unsafe { Path::new(CStr::from_ptr(filename).to_str().unwrap()) };
@@ -77,14 +78,18 @@ pub unsafe extern "C" fn qkrt_sampler_job_write_payload(
     } else {
         unsafe { Some(CStr::from_ptr(runtime).to_str().unwrap().to_string()) }
     };
-    //    let tags = if tags.is_null() {
-    //        None
-    //    } else {
-    //        unsafe { Some(CStr::from_ptr(tags).to_str().unwrap().to_string()) }
-    //    };
-
-    let model = create_sampler_job_payload(&circuit, backend, Some(shots), runtime, None);
+    let tags = c_str_array_to_vec(tags);
+    let model = create_sampler_job_payload(&circuit, backend, Some(shots), runtime, tags);
     serde_json::to_writer_pretty(file, &model).unwrap();
+}
+
+unsafe fn c_str_array_to_vec(ptr: *const *const c_char) -> Option<Vec<String>> {
+    if ptr.is_null() { return None; }
+    let it = std::iter::successors(Some(ptr), |p| Some(p.add(1)))
+        .map(|p| *p)
+        .take_while(|p| !p.is_null())
+        .map(|p| CStr::from_ptr(p).to_str().unwrap().to_owned());
+    Some(it.collect())
 }
 
 #[no_mangle]
@@ -210,6 +215,7 @@ pub unsafe extern "C" fn qkrt_sampler_job_run(
     circuit: *mut QkCircuit,
     shots: i32,
     runtime: *const c_char,
+    tags: *const *const c_char,
 ) -> ExitCode {
     if out.is_null() {
         return ExitCode::NullPointerError;
@@ -227,6 +233,7 @@ pub unsafe extern "C" fn qkrt_sampler_job_run(
     } else {
         unsafe { Some(CStr::from_ptr(runtime).to_str().unwrap().to_string()) }
     };
+    let tags = c_str_array_to_vec(tags);
     let shots = if shots < 0 { None } else { Some(shots) };
     let job = check_result!(rt.block_on(submit_sampler_job(
         service,
@@ -234,7 +241,7 @@ pub unsafe extern "C" fn qkrt_sampler_job_run(
         &Circuit(circuit),
         shots,
         runtime,
-        None,
+        tags,
     )));
     *out = Box::into_raw(Box::new(job));
     ExitCode::Success

--- a/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
+++ b/include/qiskit_ibm_runtime/qiskit_ibm_runtime.h
@@ -126,10 +126,13 @@ extern const char* qkrt_backend_instance_name(Backend *backend);
  * @param circuit A handle to the circuit to run.
  * @param shots The number of shots for this run.
  * @param runtime The name of the runtime.
+ * @param tags A pointer to a NULL-terminated array of tags.
  *
  * @return An exit code to indicate the status of the call.
  */
-extern int32_t qkrt_sampler_job_run(Job **out, Service *service, Backend *backend, QkCircuit *circuit, int32_t shots, char *runtime);
+extern int32_t qkrt_sampler_job_run(Job **out, Service *service, Backend *backend, QkCircuit *circuit, int32_t shots, char *runtime, const char *const *tags);
+
+extern int32_t qkrt_sampler_job_write_payload(QkCircuit *circuit, int32_t shots, char *backend, char *runtime, char *filename, const char *const *tags);
 
 /**
  * Submit a new estimator job given a circuit, observable, and the backend to run it on.

--- a/samples/test_ghz_sampler_run.c
+++ b/samples/test_ghz_sampler_run.c
@@ -76,7 +76,7 @@ int main(int argc, char *arv[]) {
     // Run Job on backend 
     int32_t shots = 10000;
     Job *job;
-    res = qkrt_sampler_job_run(&job, service, backends[selected_backend], transpile_result.circuit, shots, NULL);
+    res = qkrt_sampler_job_run(&job, service, backends[selected_backend], transpile_result.circuit, shots, NULL, NULL);
     if (res != 0) {
         printf("job submit failed with code: %d\n", res);
         goto cleanup_search;

--- a/samples/test_job_submit.c
+++ b/samples/test_job_submit.c
@@ -42,6 +42,10 @@ int main(int argc, char *arv[]) {
         qk_circuit_measure(qc, i, i);
     }
     int32_t shots = 4196;
+
+    static const char *const tags[] = {"tag1", "tag2", NULL};
+
+    qkrt_sampler_job_write_payload(qc, shots, "ibm_backend_name", "the_runtime", "test_before_json_tags.qpy", tags);
     generate_qpy(qc, "test_before_json.qpy");
 
     int res = 0;
@@ -77,7 +81,7 @@ int main(int argc, char *arv[]) {
     printf("\nyou have selected backend: %s\n", qkrt_backend_name(backends[selected_backend]));
 
     Job *job;
-    res = qkrt_sampler_job_run(&job, service, backends[selected_backend], qc, shots, NULL);
+    res = qkrt_sampler_job_run(&job, service, backends[selected_backend], qc, shots, NULL, tags);
     if (res != 0) {
         printf("job submit failed with code: %d\n", res);
         goto cleanup_search;

--- a/samples/test_lucj_fe4s4.c
+++ b/samples/test_lucj_fe4s4.c
@@ -65,11 +65,11 @@ int main(int argc, char *arv[]) {
         printf("transpilation failed with: %s", error);
         goto cleanup_transpile;
     }
-    
+
     // Submit a sampler job with transpiled circuit on backend
     int32_t shots = 10000;
     Job *job;
-    res = qkrt_sampler_job_run(&job, service, backends[selected_backend], transpile_result.circuit, shots, NULL);
+    res = qkrt_sampler_job_run(&job, service, backends[selected_backend], transpile_result.circuit, shots, NULL, NULL);
     if (res != 0) {
         printf("job submit failed with code: %d\n", res);
         goto cleanup_search;

--- a/tests/test_qpy.c
+++ b/tests/test_qpy.c
@@ -15,6 +15,13 @@
 
 #include <qiskit.h>
 
+extern int32_t qkrt_sampler_job_write_payload(QkCircuit *circuit, int32_t shots,
+                                              char *backend,
+                                              char *runtime,
+                                              char *filename,
+                                              const char *const *tags);
+
+
 extern void generate_qpy(QkCircuit *circuit, char *filename);
 
 int main(int argc, char* arv[]) {
@@ -28,5 +35,7 @@ int main(int argc, char* arv[]) {
     for(int i = 0; i < 200; i++) {
         qk_circuit_measure(qc, i, i);
     }
+    static const char *const tags[] = {"tag1", "tag2", NULL};
+    qkrt_sampler_job_write_payload(qc, 1024, "ibm_backend_name", "the_runtime", "test_tags.qpy", tags);
     generate_qpy(qc, "test.qpy");
 }


### PR DESCRIPTION
Add a parameter for tags to the end of the signature of these functions:

```c
qkrt_sampler_job_write_payload
qkrt_sampler_job_run
```

Programs in ./tests/ and ./samples/ are modified to pass an array of tags, where relevant.

Closes #22