### PR TITLE
Update README for supported Qiskit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ but expose that to C.
 > [!WARNING]
 > This library is an early prototype and is still under active development.
 > There are currently no backwards compatibility guarantees as the library
-> is developed. This library currently only supports the Qiskit minor versions,
+> is developed. This library currently only supports the Qiskit minor versions
 > 2.2, 2.3, and 2.4.
 
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ but expose that to C.
 > [!WARNING]
 > This library is an early prototype and is still under active development.
 > There are currently no backwards compatibility guarantees as the library
-> is developed. This library also only supports a single Qiskit version at a
-> time, currently only 2.2.0 is supported.
+> is developed. This library currently only supports the Qiskit minor versions,
+> 2.2, 2.3, and 2.4.
 
 
 ## Getting Started
@@ -59,4 +59,3 @@ This software is licensed under the Apache 2.0 license.
 While most source files include a license header, some generated source files do not
 (including sources from crates `ibm-quantum-platform-api`, `ibmcloud-global-search-api`,
 and `ibmcloud-iam-api`). All of these sources are still provided under Apache 2.0.
-


### PR DESCRIPTION
This commit updates the client README to document that it supports the 2.2, 2.3, and 2.4 release. Testing via the C code in the samples directory this library works fine with all 3 minor versions of Qiskit listed in the README now. When I originally added that warning box we were debating making backwards incompatible changes to how instructions were queried in the C API for Qiskit 2.3.0 and that would have potentially broken the client for QPY generation. We still might have incompatibilities with future releases until the Qiskit C API stabilizes so we need to be explicit about the versions that will work still.