### PR TITLE
Prepare 0.39.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "qiskit-ibm-runtime"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "base64-simd",
  "binrw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.38.0"
+version = "0.39.0"
 rust-version = "1.79"
 license = "Apache-2.0"
 


### PR DESCRIPTION
- [x] Merge issues on the [milestone](https://github.com/Qiskit/qiskit-ibm-runtime-c/milestone/1)
- [ ] Merge this PR
- [ ] Push a tag

Some notes:
- At some point, we'll likely want to configure GitHub Actions to make a release from the tag on GitHub.  This is simple enough that we might as well do it for this release, even though I don't feel it is strictly necessary to make the release
- This bumps the version even though there has not yet been a tagged 0.38.0 release.  I chose to do this because the version number 0.38.0 has been used to distribute an initial version of this package [in JuliaPackaging/Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/blob/9b38c7d9bf1a3d70e2f5c09b8a0537c8d498f38e/Q/qiskit_ibm_runtime/build_tarballs.jl#L6), and there has been an API change since then, in #11.  Bumping the version is thus best from the perspective of QiskitIBMRuntimeC.jl.