### PR TITLE
Fix typo in no clbit case qpy generation

### DIFF
--- a/crates/client/src/generate_qpy.rs
+++ b/crates/client/src/generate_qpy.rs
@@ -41,7 +41,7 @@ pub fn generate_qpy_payload(circuit: &qiskit_circuit::Circuit) -> BinResult<Vec<
     .write(&mut writer)?;
     qpy_formats::ProgramType { type_key: b'q' }.write(&mut writer)?;
     let empty_json = "{}";
-    let registers = if circuit.num_clbits() == 0 {
+    let registers = if circuit.num_clbits() != 0 {
         vec![qpy_formats::RegisterV4Pack {
             register_type: b'c',
             standalone: true as u8,


### PR DESCRIPTION
In #17 the logic check was done backwards. Specifically the condition was an empty vec should be used if there are no clbits, but the if condition was incorrectly using vec![] if there were clbits. This commit fixes the oversight and corrects the logic so it is only populating the classical registers field in the QPY if there are any clbits (not if there are not any clbits).